### PR TITLE
Further increase Memory to avoid OOM issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ ENV CLEAN_AFTER_BUILD true
 ENV WITH_SU false
 
 # Provide a default JACK configuration in order to avoid out-of-memory issues
-ENV ANDROID_JACK_VM_ARGS "-Dfile.encoding=UTF-8 -XX:+TieredCompilation -Xmx4G"
+ENV ANDROID_JACK_VM_ARGS "-Dfile.encoding=UTF-8 -XX:+TieredCompilation -Xmx8G"
 
 # Custom packages to be installed
 ENV CUSTOM_PACKAGES ''
@@ -130,7 +130,7 @@ ENV DELETE_OLD_LOGS 0
 ENV OPENDELTA_BUILDS_JSON ''
 
 # set the java tool options max memory size
-ENV JAVA_TOOL_OPTIONS "-Xmx6g"
+ENV JAVA_TOOL_OPTIONS "-Xmx12g"
 
 # You can optionally specify a USERSCRIPTS_DIR volume containing these scripts:
 #  * begin.sh, run at the very beginning


### PR DESCRIPTION
This might be very Xiaomi specific and maybe even only required for Xiaomi Mi Mix. However even with your increased memory allocation I ran into out of memory issues when building LineageOS 16.0 for Xiaomi Mi Mix. I know that those settings look very "expensive" but they can be easily archived by adding an adequately sized swap file to the system. If you don't feel comfortable with "hard coding" those in, maybe we could add a comment to suggest those settings in case OOM issues arise?